### PR TITLE
[로그인] 임시 로그인 페이지와 임시 기본 페이지 레이아웃 구성

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import { ChakraProvider } from '@/providers/chakraProvider';
 import QueryClientProvider from '@/providers/queryClientProvider';
+import MainLayout from '@/component/layout/mainLayout';
 import './globals.css';
 
 const inter = Inter({ subsets: ['latin'] });
@@ -20,7 +21,9 @@ export default function RootLayout({
     <html lang="en">
       <body className={inter.className}>
         <ChakraProvider>
-          <QueryClientProvider>{children}</QueryClientProvider>
+          <QueryClientProvider>
+            <MainLayout>{children}</MainLayout>
+          </QueryClientProvider>
         </ChakraProvider>
       </body>
     </html>

--- a/src/app/login/kakaoLoginButton.tsx
+++ b/src/app/login/kakaoLoginButton.tsx
@@ -1,3 +1,5 @@
+// https://developers.kakao.com/docs/latest/ko/kakaologin/design-guide
+// https://www.figma.com/community/file/1232637617420363657
 import { Button, ButtonProps } from '@chakra-ui/react';
 import KakaoSymbol from '@/component/icon/kakaoSymbol';
 

--- a/src/app/login/kakaoLoginButton.tsx
+++ b/src/app/login/kakaoLoginButton.tsx
@@ -1,0 +1,23 @@
+import { Button, ButtonProps } from '@chakra-ui/react';
+import KakaoSymbol from '@/component/icon/kakaoSymbol';
+
+const KakaologinButton = (props: ButtonProps) => (
+  <Button
+    {...props}
+    h={'45px'}
+    fontSize={'15px'}
+    borderRadius={'12px'}
+    textColor={'#000000D9'}
+    bgColor={'#FEE500'}
+    _hover={{
+      bgColor: '#FFEB3B',
+    }}
+    px={'14px'}
+    py={'11px'}
+    leftIcon={<KakaoSymbol boxSize={'18px'} color={'#000000'} />}
+  >
+    카카오 로그인
+  </Button>
+);
+
+export default KakaologinButton;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,16 @@
+import { Heading, VStack } from '@chakra-ui/react';
+import KakaologinButton from './kakaoLoginButton';
+
+const Login = () => {
+  return (
+    // NOTE : center에 위치하는 컨텐츠의 최대 너비는 모바일 화면을 기준으로 600px으로 설정함 (논의 필요...)
+    <VStack w={'100%'} maxW={'600px'} spacing={'4'} alignItems={'stretch'}>
+      <Heading as={'span'} fontSize={'2xl'}>
+        로그인 페이지
+      </Heading>
+      <KakaologinButton />
+    </VStack>
+  );
+};
+
+export default Login;

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,4 +1,4 @@
-import { Heading, VStack } from '@chakra-ui/react';
+import { Box, Heading, VStack } from '@chakra-ui/react';
 import KakaologinButton from './kakaoLoginButton';
 
 const Login = () => {
@@ -8,6 +8,9 @@ const Login = () => {
       <Heading as={'span'} fontSize={'2xl'}>
         로그인 페이지
       </Heading>
+      <Box h={'20'} w={'20'} mx={'auto'} bgColor={'orange'}>
+        로고
+      </Box>
       <KakaologinButton />
     </VStack>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,8 +2,8 @@ import { Heading } from '@chakra-ui/react';
 
 export default function Home() {
   return (
-    <main>
+    <>
       <Heading color={'blueviolet'}>Home</Heading>
-    </main>
+    </>
   );
 }

--- a/src/component/icon/kakaoSymbol.tsx
+++ b/src/component/icon/kakaoSymbol.tsx
@@ -1,5 +1,3 @@
-// https://developers.kakao.com/docs/latest/ko/kakaologin/design-guide
-// https://www.figma.com/community/file/1232637617420363657
 import { Icon, IconProps } from '@chakra-ui/react';
 
 const KakaoSymbol = (props: IconProps) => (

--- a/src/component/icon/kakaoSymbol.tsx
+++ b/src/component/icon/kakaoSymbol.tsx
@@ -1,0 +1,21 @@
+// https://developers.kakao.com/docs/latest/ko/kakaologin/design-guide
+// https://www.figma.com/community/file/1232637617420363657
+import { Icon, IconProps } from '@chakra-ui/react';
+
+const KakaoSymbol = (props: IconProps) => (
+  <Icon viewBox="0 0 200 200" {...props}>
+    <svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <g clip-path="url(#clip0_103_60)">
+        <path
+          fill-rule="evenodd"
+          clip-rule="evenodd"
+          d="M12.0001 0.800003C5.37225 0.800003 0 4.95061 0 10.0697C0 13.2534 2.07788 16.06 5.24205 17.7293L3.91072 22.5927C3.7931 23.0224 4.28457 23.3649 4.66197 23.1159L10.4978 19.2643C10.9903 19.3118 11.4908 19.3395 12.0001 19.3395C18.6274 19.3395 24 15.1891 24 10.0697C24 4.95061 18.6274 0.800003 12.0001 0.800003Z"
+          fill="black"
+          fill-opacity="0.85"
+        />
+      </g>
+    </svg>
+  </Icon>
+);
+
+export default KakaoSymbol;

--- a/src/component/layout/header.tsx
+++ b/src/component/layout/header.tsx
@@ -4,7 +4,7 @@ const Header = () => {
   return (
     <HStack
       as={'header'}
-      h={'4.5rem'}
+      h={16}
       w={'100%'}
       px={'6'}
       justify="space-between"

--- a/src/component/layout/header.tsx
+++ b/src/component/layout/header.tsx
@@ -1,0 +1,20 @@
+import { Box, HStack } from '@chakra-ui/react';
+
+const Header = () => {
+  return (
+    <HStack
+      as={'header'}
+      h={'4.5rem'}
+      w={'100%'}
+      px={'6'}
+      justify="space-between"
+      bgColor={'orange'}
+    >
+      <Box>메뉴</Box>
+      <Box>로고</Box>
+      <Box>알림</Box>
+    </HStack>
+  );
+};
+
+export default Header;

--- a/src/component/layout/mainLayout.tsx
+++ b/src/component/layout/mainLayout.tsx
@@ -1,0 +1,29 @@
+import { Box, VStack } from '@chakra-ui/react';
+import Header from './header';
+
+const MainLayout = ({ children }: { children: React.ReactNode }) => (
+  <VStack
+    spacing={'0'}
+    h={'fit-content'}
+    w={'100vw'}
+    minH={'100vh'}
+    maxW={'1280px'} // Note : 왜 1280px로 설정했는지?
+  >
+    <Header />
+    <Box as={'main'} flexGrow={'1'} w={'100%'}>
+      {children}
+    </Box>
+    <Box
+      as={'footer'}
+      h={'32'}
+      w={'100%'}
+      mb={'20'}
+      mt={'12'}
+      bgColor={'orange'}
+    >
+      footer
+    </Box>
+  </VStack>
+);
+
+export default MainLayout;

--- a/src/component/layout/mainLayout.tsx
+++ b/src/component/layout/mainLayout.tsx
@@ -10,7 +10,7 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => (
     maxW={'1280px'} // Note : 왜 1280px로 설정했는지?
   >
     <Header />
-    <Center as={'main'} flexGrow={'1'} w={'100%'}>
+    <Center as={'main'} flexGrow={'1'} w={'100%'} px={'6'}>
       {children}
     </Center>
     <Box

--- a/src/component/layout/mainLayout.tsx
+++ b/src/component/layout/mainLayout.tsx
@@ -1,4 +1,4 @@
-import { Box, VStack } from '@chakra-ui/react';
+import { Box, Center, VStack } from '@chakra-ui/react';
 import Header from './header';
 
 const MainLayout = ({ children }: { children: React.ReactNode }) => (
@@ -10,9 +10,9 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => (
     maxW={'1280px'} // Note : 왜 1280px로 설정했는지?
   >
     <Header />
-    <Box as={'main'} flexGrow={'1'} w={'100%'}>
+    <Center as={'main'} flexGrow={'1'} w={'100%'}>
       {children}
-    </Box>
+    </Center>
     <Box
       as={'footer'}
       h={'32'}


### PR DESCRIPTION
## #️⃣ 관련 이슈

<!-- 이 PR이 완료되면 닫을 이슈번호 -->

- resolved: #4 

## 📝 작업 내용

<!-- 간단한 작업 내용 -->

<img width="1348" alt="Screen_Shot 2024-07-23 01 34 59" src="https://github.com/user-attachments/assets/df12bfa6-020c-4964-8aae-83c8d3e17180">

- 페이지 기본 레이아웃 구성 (헤더 / 푸터 / 메인)
- 카카오 디자인 가이드에 맞춰 로그인 버튼 추가
- 임시 로그인 페이지 구성

## 💬 기타

<!-- 더 설명할 내용이 있다면 이곳에 -->

[카카오 디자인 가이드](https://developers.kakao.com/docs/latest/ko/kakaologin/design-guide)